### PR TITLE
Field is only required if the input is not hidden

### DIFF
--- a/packages/plugin/src/Fields/Pro/FileDragAndDropField.php
+++ b/packages/plugin/src/Fields/Pro/FileDragAndDropField.php
@@ -104,7 +104,7 @@ class FileDragAndDropField extends FileUploadField implements ExtraFieldInterfac
 
         $file = $_FILES[$handle] ?? null;
         if (!$file) {
-            if ($this->isRequired() && empty($this->getValue())) {
+            if ($this->isRequired() && !$this->isHidden() && empty($this->getValue())) {
                 return [$this->translate('This field is required')];
             }
 


### PR DESCRIPTION
The drag and drop file type was requiring a file to be selected even if the ruleset resulted in the field being hidden.

Used the conditional check in the old File Upload Field type as a reference: https://github.com/solspace/craft-freeform/blob/master/packages/plugin/src/Fields/FileUploadField.php#L259