### PR TITLE
fix: Ensure array exists before looping, rule-set form handler

### DIFF
--- a/packages/scripts/src/lib/plugin/handlers/form/rule-set.js
+++ b/packages/scripts/src/lib/plugin/handlers/form/rule-set.js
@@ -66,27 +66,29 @@ class RuleSetHandler {
           value,
         });
 
-        for (let elementIndex = 0; elementIndex < elements.length; elementIndex++) {
-          const element = elements[elementIndex];
+        if (elements && elements.length) {
+          for (let elementIndex = 0; elementIndex < elements.length; elementIndex++) {
+            const element = elements[elementIndex];
 
-          let eventType;
-          switch (this.getInputType(element)) {
-            case 'checkbox':
-            case 'radio':
-              eventType = 'click';
-              break;
+            let eventType;
+            switch (this.getInputType(element)) {
+              case 'checkbox':
+              case 'radio':
+                eventType = 'click';
+                break;
 
-            case 'select':
-            case 'date':
-              eventType = 'change';
-              break;
+              case 'select':
+              case 'date':
+                eventType = 'change';
+                break;
 
-            default:
-              eventType = 'keyup';
-              break;
+              default:
+                eventType = 'keyup';
+                break;
+            }
+
+            element.addEventListener(eventType, () => container.dispatchEvent(this.createRuleApplicationEvent()));
           }
-
-          element.addEventListener(eventType, () => container.dispatchEvent(this.createRuleApplicationEvent()));
         }
       });
 


### PR DESCRIPTION
We have encountered an issue with this section of code stemming from the fact that elements may not be an initiated variable / array (with the `.length` property)

I have simply thrown in a if statement around the loop to avoid running it if array is not initialized. Alternatively if we know the elements variable on line 46 is definitely going to be an array, we can initialize it there and it will solve this issue.

Let me know any insights the team have on this issue.