### PR TITLE
Use new Campaign integration method

### DIFF
--- a/packages/plugin/src/Integrations/MailingLists/Campaign.php
+++ b/packages/plugin/src/Integrations/MailingLists/Campaign.php
@@ -97,8 +97,8 @@ class Campaign extends AbstractMailingListIntegration
 
         foreach ($emails as $email) {
             // The `createAndSubscribeContact` method was added in Campaign v2.1.0.
-            if (method_exists(Campaign::$plugin->forms, 'createAndSubscribeContact')) {
-                Campaign::$plugin->forms->createAndSubscribeContact($email, $mappedValues, $mailingListElement, 'Freeform', $source);
+            if (method_exists(CampaignPlugin::$plugin->forms, 'createAndSubscribeContact')) {
+                CampaignPlugin::$plugin->forms->createAndSubscribeContact($email, $mappedValues, $mailingListElement, 'Freeform', $source);
             }
             // TODO: remove this in Freeform v5, assuming it requires Craft 5, in which case Campaign v3 will be required.
             else {

--- a/packages/plugin/src/Integrations/MailingLists/Campaign.php
+++ b/packages/plugin/src/Integrations/MailingLists/Campaign.php
@@ -96,34 +96,38 @@ class Campaign extends AbstractMailingListIntegration
         }
 
         foreach ($emails as $email) {
-            $contact = CampaignPlugin::$plugin->contacts->getContactByEmail($email);
-
-            if (null === $contact) {
-                $contact = new ContactElement();
-                $contact->email = $email;
+            // The `createAndSubscribeContact` method was added in Campaign v2.1.0.
+            if (method_exists(Campaign::$plugin->forms, 'createAndSubscribeContact')) {
+                Campaign::$plugin->forms->createAndSubscribeContact($email, $mappedValues, $mailingListElement, 'Freeform', $source);
             }
+            // TODO: remove this in Freeform v5, assuming it requires Craft 5, in which case Campaign v3 will be required.
+            else {
+                $contact = CampaignPlugin::$plugin->contacts->getContactByEmail($email);
 
-            foreach ($mappedValues as $key => $value) {
-                $contact->setFieldValue($key, $value);
-            }
-
-            // If verification required
-            if ($mailingListElement->getMailingListType()->subscribeVerificationRequired) {
-                $pendingContact = new PendingContactModel();
-                $pendingContact->pid = StringHelper::uniqueId('p');
-                $pendingContact->email = $email;
-                $pendingContact->mailingListId = $mailingListElement->id;
-                $pendingContact->source = $source;
-                $pendingContact->fieldData = $contact->getSerializedFieldValues();
-
-                if (CampaignPlugin::$plugin->pendingContacts->savePendingContact($pendingContact)) {
-                    CampaignPlugin::$plugin->forms->sendVerifySubscribeEmail(
-                        $pendingContact,
-                        $mailingListElement
-                    );
+                if (null === $contact) {
+                    $contact = new ContactElement();
+                    $contact->email = $email;
                 }
-            } else {
-                if (\Craft::$app->getElements()->saveElement($contact)) {
+
+                // Set field values
+                $contact->setFieldValues($mappedValues);
+
+                // If verification required
+                if ($mailingListElement->getMailingListType()->subscribeVerificationRequired) {
+                    $pendingContact = new PendingContactModel();
+                    $pendingContact->pid = StringHelper::uniqueId('p');
+                    $pendingContact->email = $email;
+                    $pendingContact->mailingListId = $mailingListElement->id;
+                    $pendingContact->source = $source;
+                    $pendingContact->fieldData = $contact->getSerializedFieldValues();
+
+                    if (CampaignPlugin::$plugin->pendingContacts->savePendingContact($pendingContact)) {
+                        CampaignPlugin::$plugin->forms->sendVerifySubscribeEmail(
+                            $pendingContact,
+                            $mailingListElement
+                        );
+                    }
+                } elseif (\Craft::$app->getElements()->saveElement($contact)) {
                     CampaignPlugin::$plugin->forms->subscribeContact(
                         $contact,
                         $mailingListElement,


### PR DESCRIPTION
I've made it easier to integrate with the Campaign plugin from v2.1.0. This PR uses the new `FormsService::createAndSubscribeContact` method, falling back to the manual way of doing things if the method does not exist (if an older version of Campaign is installed). I also added a `TODO` to remind you to remove the manual approach in the next major version of Freeform.