### PR TITLE
Fix warning for permissions

### DIFF
--- a/packages/plugin/src/Freeform.php
+++ b/packages/plugin/src/Freeform.php
@@ -591,14 +591,14 @@ class Freeform extends Plugin
 
     private function initWidgets()
     {
-        if (!PermissionHelper::checkPermission('accessPlugin-freeform')) {
-            return;
-        }
-
         Event::on(
             Dashboard::class,
             Dashboard::EVENT_REGISTER_WIDGET_TYPES,
             function (RegisterComponentTypesEvent $event) {
+                if (!PermissionHelper::checkPermission('accessPlugin-freeform')) {
+                    return;
+                }
+                
                 $finder = new Finder();
 
                 $namespace = 'Solspace\Freeform\Widgets';


### PR DESCRIPTION
Checking for the permissions outside the event triggers the `Element query executed before Craft is fully initialized.` warning on every request.

This change will fix the warning.