### PR TITLE
[SFT-90]: Support sameSiteCookieValue

### DIFF
--- a/packages/plugin/src/Bundles/Form/Tracking/Cookies.php
+++ b/packages/plugin/src/Bundles/Form/Tracking/Cookies.php
@@ -32,11 +32,14 @@ class Cookies extends FeatureBundle
         setcookie(
             $name,
             $value,
-            (int) strtotime('+1 year'),
-            '/',
-            \Craft::$app->getConfig()->getGeneral()->defaultCookieDomain,
-            true,
-            true
+            [
+                'expires' => (int) strtotime('+1 year'),
+                'path' => '/',
+                'domain' => \Craft::$app->getConfig()->getGeneral()->defaultCookieDomain,
+                'secure' => true,
+                'httponly' => true,
+                'samesite' => \Craft::$app->getConfig()->getGeneral()->sameSiteCookieValue ?? 'Lax',
+            ],
         );
 
         $_COOKIE[$name] = $value;


### PR DESCRIPTION
- Adds `SameSite` attribute for cookies set after form submission.
- The value is taken from Craft general config `sameSiteCookieValue` or if not set, falls back to Lax.

See: 

https://github.com/solspace/craft-freeform/discussions/469
https://craftcms.com/docs/4.x/config/general.html#samesitecookievalue either 'lax' or ideally 'strict' for all cookies.
https://web.dev/samesite-cookies-explained/