### PR TITLE
[SFT-89]: reCAPTCHA scripts load on ANY page that includes a Freeform…

### DIFF
--- a/packages/plugin/src/Bundles/Captchas/HCaptcha.php
+++ b/packages/plugin/src/Bundles/Captchas/HCaptcha.php
@@ -47,6 +47,11 @@ class HCaptcha extends FeatureBundle
 
     public function validateCheckbox(ValidateEvent $event)
     {
+        $recaptchaDisabled = !$event->getForm()->isRecaptchaEnabled();
+        if ($recaptchaDisabled) {
+            return;
+        }
+
         $field = $event->getField();
         if (($field instanceof RecaptchaField) && !$this->validateResponse()) {
             $message = $this->getSettings()->recaptchaErrorMessage;

--- a/packages/plugin/src/Bundles/Captchas/ReCaptcha.php
+++ b/packages/plugin/src/Bundles/Captchas/ReCaptcha.php
@@ -57,7 +57,8 @@ class ReCaptcha extends FeatureBundle
 
     public function validateRecaptchaV2Checkbox(ValidateEvent $event)
     {
-        if ($this->isRecaptchaTypeSkipped(Settings::RECAPTCHA_TYPE_V2_CHECKBOX)) {
+        $recaptchaDisabled = !$event->getForm()->isRecaptchaEnabled();
+        if ($recaptchaDisabled || $this->isRecaptchaTypeSkipped(Settings::RECAPTCHA_TYPE_V2_CHECKBOX)) {
             return;
         }
 

--- a/packages/plugin/src/Library/Composer/Components/Form.php
+++ b/packages/plugin/src/Library/Composer/Components/Form.php
@@ -33,6 +33,7 @@ use Solspace\Freeform\Events\Forms\ValidationEvent;
 use Solspace\Freeform\Fields\CheckboxField;
 use Solspace\Freeform\Fields\HiddenField;
 use Solspace\Freeform\Fields\MailingListField;
+use Solspace\Freeform\Fields\RecaptchaField;
 use Solspace\Freeform\Form\Bags\AttributeBag;
 use Solspace\Freeform\Form\Bags\PropertyBag;
 use Solspace\Freeform\Freeform;
@@ -547,6 +548,10 @@ abstract class Form implements FormTypeInterface, \JsonSerializable, \Iterator, 
         }
 
         if (\count($this->getLayout()->getPaymentFields())) {
+            return false;
+        }
+
+        if (!$this->getLayout()->hasFields(RecaptchaField::class)) {
             return false;
         }
 


### PR DESCRIPTION
… form, regardless of whether the form(s) have reCAPTCHA enabled

- Checks if a reCaptcha field is present on the form.
  - If the field exists, reCaptcha related form attributes are added (which in turn then allows the loading of the reCaptcha JS script.
  - If the field does not exist, no reCaptcha related form attributes are added and therefore no JS script is loaded.