### PR TITLE
[SFT-89]: reCAPTCHA scripts load on ANY page that includes a Freeform form, regardless of whether the form(s) have reCAPTCHA enabled

### DIFF
--- a/packages/plugin/src/Bundles/Captchas/ReCaptcha.php
+++ b/packages/plugin/src/Bundles/Captchas/ReCaptcha.php
@@ -111,12 +111,32 @@ class ReCaptcha extends FeatureBundle
         $form = $event->getForm();
         $settings = $this->getSettings();
 
+        // If global settings are false, then bail
         if (!$settings->recaptchaEnabled) {
             return;
         }
 
+        // If using the invisible recaptcha and the form settings for "Enable Captchas" is false, then bail
         if ($settings->isInvisibleRecaptchaSetUp() && !$form->isRecaptchaEnabled()) {
             return;
+        }
+
+        // If using the checkbox recaptcha
+        if (!$settings->isInvisibleRecaptchaSetUp()) {
+            // ... and the form doesn't have a recaptcha field, then bail
+            if (!$form->getLayout()->hasFields(RecaptchaField::class)) {
+                return;
+            }
+
+            // or if the form has a payment fields, then bail
+            if (\count($form->getLayout()->getPaymentFields())) {
+                return;
+            }
+
+            // or if the form has the property disableRecaptcha set, then bail
+            if ($form->getPropertyBag()->get(form::DATA_DISABLE_RECAPTCHA)) {
+                return;
+            }
         }
 
         $recaptchaKey = \Craft::parseEnv($settings->recaptchaKey);

--- a/packages/plugin/src/Library/Composer/Components/Form.php
+++ b/packages/plugin/src/Library/Composer/Components/Form.php
@@ -33,7 +33,6 @@ use Solspace\Freeform\Events\Forms\ValidationEvent;
 use Solspace\Freeform\Fields\CheckboxField;
 use Solspace\Freeform\Fields\HiddenField;
 use Solspace\Freeform\Fields\MailingListField;
-use Solspace\Freeform\Fields\RecaptchaField;
 use Solspace\Freeform\Form\Bags\AttributeBag;
 use Solspace\Freeform\Form\Bags\PropertyBag;
 use Solspace\Freeform\Freeform;
@@ -541,25 +540,10 @@ abstract class Form implements FormTypeInterface, \JsonSerializable, \Iterator, 
         return $this->getValidationProperties()->getErrorMessage();
     }
 
+    // Only used for invisible recaptcha
     public function isRecaptchaEnabled(): bool
     {
-        if (!$this->recaptchaEnabled) {
-            return false;
-        }
-
-        if (\count($this->getLayout()->getPaymentFields())) {
-            return false;
-        }
-
-        if (!$this->getLayout()->hasFields(RecaptchaField::class)) {
-            return false;
-        }
-
-        if ($this->getPropertyBag()->get(self::DATA_DISABLE_RECAPTCHA)) {
-            return false;
-        }
-
-        return true;
+        return $this->recaptchaEnabled;
     }
 
     public function isGtmEnabled(): bool
@@ -1066,9 +1050,9 @@ abstract class Form implements FormTypeInterface, \JsonSerializable, \Iterator, 
     }
 
     /**
-     * @throws ComposerException
-     *
      * @return Properties\ValidationProperties
+     *
+     * @throws ComposerException
      */
     public function getValidationProperties()
     {
@@ -1076,9 +1060,9 @@ abstract class Form implements FormTypeInterface, \JsonSerializable, \Iterator, 
     }
 
     /**
-     * @throws ComposerException
-     *
      * @return Properties\AdminNotificationProperties
+     *
+     * @throws ComposerException
      */
     public function getAdminNotificationProperties()
     {


### PR DESCRIPTION
The ReCaptcha Javascript was still loading in some cases.

I've moved the logic for Checkbox ReCaptcha into `ReCaptcha.php` itself since the logic within `Form.php -> isRecaptchaEnabled` was really only used for Invisible ReCaptcha's but as mentioned above caused another bug when switching between ReCaptcha setup types in the CP...

To replicate...

I initially setup a Checkbox ReCaptcha. Added additional logic to check if ReCaptcha Field existed on the form. If it did, all good. However, if it didn't then we'd skip adding the form tag attributes and therefore preventing the Javascript injection...

This seemed to work fine. G and I tested, all good. Kelsey tested and things didn't work as expected.

Switching between Checkbox and Invisible ReCaptcha types and testing the logic again, the check for the ReCaptcha field on the form would prevent adding the form tag attributes and therefore preventing the Javascript injection... BUT there was a 3rd issue...

If I created a form with Invisible ReCaptcha setup and checked the Enable ReCaptcha and saved it, all was good.
If I then went back and unchecked the Enable ReCaptcha and saved the form, all was still good. 

However, if I switched back to Checkbox ReCaptcha in the setup, the form with the ReCaptcha field added would fail when it should have added the form tag attributes and injected the required Javascript.

I'll try to explain...

When switching between Invisible and Checkbox ReCaptchas, the checkbox for Enable ReCaptcha is shown or hidden but the actual `recaptchaEnabled` value stored in the database stays the same. E.g its previous value. Updating the form settings wasn't removing this value as the checkbox field was not being sent since it was hidden.

I hope I've explained that clear enough to understand the bug.

The changes in this PR prevent stale `recaptchaEnabled` values from previous setups causing havoc, plus the ReCaptcha  logic is removed from `Form.php`.