### PR TITLE
fix(SFT-2731): ActiveCampaign CRM

### DIFF
--- a/packages/plugin/src/Integrations/CRM/ActiveCampaign/Versions/ActiveCampaignV3.php
+++ b/packages/plugin/src/Integrations/CRM/ActiveCampaign/Versions/ActiveCampaignV3.php
@@ -120,6 +120,8 @@ class ActiveCampaignV3 extends BaseActiveCampaignIntegration
 
     private array $dealProps = [];
 
+    private array $accountProps = [];
+
     private array $contact = [];
 
     private array $deal = [];
@@ -193,7 +195,15 @@ class ActiveCampaignV3 extends BaseActiveCampaignIntegration
             $mapping = $this->processMapping($form, $this->accountMapping, self::CATEGORY_ACCOUNT);
 
             foreach ($mapping as $key => $value) {
-                $this->account[$key] = $value;
+                if (is_numeric($key)) {
+                    $this->accountProps[] = [
+                        'accountId' => null,
+                        'customFieldId' => (int) $key,
+                        'fieldValue' => $value,
+                    ];
+                } else {
+                    $this->account[$key] = $value;
+                }
             }
         }
     }
@@ -244,6 +254,21 @@ class ActiveCampaignV3 extends BaseActiveCampaignIntegration
 
                 throw $exception;
             }
+        }
+
+        if (!$this->accountId) {
+            return;
+        }
+
+        foreach ($this->accountProps as $prop) {
+            $prop['accountId'] = $this->accountId;
+
+            $response = $client->post(
+                $this->getEndpoint('/accountCustomFieldData'),
+                ['json' => ['accountCustomFieldDatum' => $prop]],
+            );
+
+            $this->triggerAfterResponseEvent(self::CATEGORY_ACCOUNT, $response);
         }
     }
 

--- a/packages/plugin/src/Integrations/CRM/ActiveCampaign/Versions/ActiveCampaignV3.php
+++ b/packages/plugin/src/Integrations/CRM/ActiveCampaign/Versions/ActiveCampaignV3.php
@@ -151,9 +151,6 @@ class ActiveCampaignV3 extends BaseActiveCampaignIntegration
     {
         if ($this->mapContact) {
             $mapping = $this->processMapping($form, $this->contactMapping, self::CATEGORY_CONTACT);
-            if (!$mapping) {
-                return;
-            }
 
             foreach ($mapping as $key => $value) {
                 if (is_numeric($key)) {
@@ -174,9 +171,6 @@ class ActiveCampaignV3 extends BaseActiveCampaignIntegration
 
         if ($this->mapDeal) {
             $mapping = $this->processMapping($form, $this->dealMapping, self::CATEGORY_DEAL);
-            if (!$mapping) {
-                return;
-            }
 
             foreach ($mapping as $key => $value) {
                 if (is_numeric($key)) {
@@ -197,9 +191,6 @@ class ActiveCampaignV3 extends BaseActiveCampaignIntegration
 
         if ($this->mapAccount) {
             $mapping = $this->processMapping($form, $this->accountMapping, self::CATEGORY_ACCOUNT);
-            if (!$mapping) {
-                return;
-            }
 
             foreach ($mapping as $key => $value) {
                 $this->account[$key] = $value;

--- a/packages/plugin/src/Integrations/CRM/ActiveCampaign/Versions/ActiveCampaignV3.php
+++ b/packages/plugin/src/Integrations/CRM/ActiveCampaign/Versions/ActiveCampaignV3.php
@@ -237,11 +237,15 @@ class ActiveCampaignV3 extends BaseActiveCampaignIntegration
             }
         } catch (\Exception $exception) {
             if (422 === $exception->getCode()) {
-                $response = $client->get($this->getEndpoint('/accounts'));
+                // The Account already exists. Search for it by name so the match is found regardless of how many Accounts exist
+                $response = $client->get(
+                    $this->getEndpoint('/accounts'),
+                    ['query' => ['search' => $this->account['name'] ?? '']],
+                );
 
                 $json = json_decode($response->getBody(), false);
 
-                foreach ($json->accounts as $account) {
+                foreach ($json->accounts ?? [] as $account) {
                     if (!empty($this->account['name']) && strtolower($account->name) === strtolower($this->account['name'])) {
                         $this->accountId = $account->id;
                         $this->logger->debug('Account already exists', ['id' => $account->id]);

--- a/packages/plugin/src/Integrations/CRM/ActiveCampaign/Versions/ActiveCampaignV3.php
+++ b/packages/plugin/src/Integrations/CRM/ActiveCampaign/Versions/ActiveCampaignV3.php
@@ -237,21 +237,11 @@ class ActiveCampaignV3 extends BaseActiveCampaignIntegration
             }
         } catch (\Exception $exception) {
             if (422 === $exception->getCode()) {
-                // The Account already exists. Search for it by name so the match is found regardless of how many Accounts exist
-                $response = $client->get(
-                    $this->getEndpoint('/accounts'),
-                    ['query' => ['search' => $this->account['name'] ?? '']],
-                );
-
-                $json = json_decode($response->getBody(), false);
-
-                foreach ($json->accounts ?? [] as $account) {
-                    if (!empty($this->account['name']) && strtolower($account->name) === strtolower($this->account['name'])) {
-                        $this->accountId = $account->id;
-                        $this->logger->debug('Account already exists', ['id' => $account->id]);
-
-                        break;
-                    }
+                // The Account already exists. Look it up by name so the match is found
+                // regardless of how many Accounts exist on the store.
+                $this->accountId = $this->fetchAccountIdByName($client, $this->account['name'] ?? '');
+                if ($this->accountId) {
+                    $this->logger->debug('Account already exists', ['id' => $this->accountId]);
                 }
             } else {
                 $this->logger->debug('Account creation failed', ['exception' => $exception->getMessage()]);
@@ -463,6 +453,43 @@ class ActiveCampaignV3 extends BaseActiveCampaignIntegration
         }
 
         return null;
+    }
+
+    private function fetchAccountIdByName(Client $client, string $name): int
+    {
+        if ('' === $name) {
+            return 0;
+        }
+
+        $limit = 100;
+        $offset = 0;
+
+        do {
+            $response = $client->get(
+                $this->getEndpoint('/accounts'),
+                [
+                    'query' => [
+                        'search' => $name,
+                        'limit' => $limit,
+                        'offset' => $offset,
+                    ],
+                ],
+            );
+
+            $json = json_decode($response->getBody(), false);
+            $accounts = $json->accounts ?? [];
+
+            foreach ($accounts as $account) {
+                if (strtolower($account->name) === strtolower($name)) {
+                    return (int) $account->id;
+                }
+            }
+
+            $offset += $limit;
+            $total = (int) ($json->meta->total ?? 0);
+        } while (\count($accounts) === $limit && $offset < $total);
+
+        return 0;
     }
 
     private function isAlreadyAssociatedAccountException(\Exception $exception): bool


### PR DESCRIPTION
- Contact, Deal and Account now map independently when multiple toggles are enabled
- Account custom field values now use their own `accountCustomFieldData` endpoint
- Account look ups are done by name and paginated (incases where multiples exist) when searching so the Contact is linked correctly 