### PR TITLE
fix(SFT-2997): exclude spam from dashboard charts by default with opt-in toggle

### DIFF
--- a/packages/plugin/src/Services/ChartsService.php
+++ b/packages/plugin/src/Services/ChartsService.php
@@ -46,6 +46,7 @@ class ChartsService extends BaseService
             ->andWhere([
                 "{$submissions}.[[formId]]" => $formIds,
                 "{$submissions}.[[isHidden]]" => false,
+                "{$submissions}.[[isSpam]]" => false,
             ])
             ->innerJoin(
                 $elements,
@@ -85,7 +86,8 @@ class ChartsService extends BaseService
         Carbon $rangeStart,
         Carbon $rangeEnd,
         array $formIds,
-        bool $aggregate = false
+        bool $aggregate = false,
+        bool $includeSpam = false
     ): LinearChartData {
         $submissions = Submission::TABLE;
 
@@ -126,9 +128,14 @@ class ChartsService extends BaseService
             $form = null;
             if ($aggregate) {
                 $query->andWhere(['in', "{$submissions}.[[formId]]", $formIds]);
+                $query->andWhere(["{$submissions}.[[isHidden]]" => false]);
             } else {
                 $form = $forms[$formId];
                 $query->andWhere(["{$submissions}.[[formId]]" => $formId, "{$submissions}.[[isHidden]]" => false]);
+            }
+
+            if (!$includeSpam) {
+                $query->andWhere(["{$submissions}.[[isSpam]]" => false]);
             }
 
             $query->innerJoin(
@@ -169,7 +176,8 @@ class ChartsService extends BaseService
     public function getRadialFormSubmissionData(
         Carbon $rangeStart,
         Carbon $rangeEnd,
-        array $forms
+        array $forms,
+        bool $includeSpam = false
     ): RadialChartData {
         $formIds = array_keys($forms);
 
@@ -182,6 +190,10 @@ class ChartsService extends BaseService
             ->andWhere(["{$submissions}.[[isHidden]]" => false])
             ->groupBy(["{$submissions}.[[formId]]"])
         ;
+
+        if (!$includeSpam) {
+            $query->andWhere(["{$submissions}.[[isSpam]]" => false]);
+        }
 
         $elements = Table::ELEMENTS;
         $query->innerJoin(

--- a/packages/plugin/src/Widgets/Pro/LinearChartsWidget.php
+++ b/packages/plugin/src/Widgets/Pro/LinearChartsWidget.php
@@ -34,6 +34,8 @@ class LinearChartsWidget extends AbstractWidget implements ExtraWidgetInterface
 
     public ?string $chartType = null;
 
+    public ?bool $includeSpam = null;
+
     public static function displayName(): string
     {
         return Freeform::getInstance()->name.' '.Freeform::t('Linear Chart');
@@ -70,6 +72,10 @@ class LinearChartsWidget extends AbstractWidget implements ExtraWidgetInterface
 
         if (null === $this->chartType) {
             $this->chartType = WidgetsService::CHART_LINE;
+        }
+
+        if (null === $this->includeSpam) {
+            $this->includeSpam = false;
         }
     }
 
@@ -137,7 +143,8 @@ class LinearChartsWidget extends AbstractWidget implements ExtraWidgetInterface
             $rangeStart,
             $rangeEnd,
             $formIds,
-            (bool) $this->aggregate
+            (bool) $this->aggregate,
+            (bool) $this->includeSpam
         );
 
         $chartData->setChartType($this->chartType);

--- a/packages/plugin/src/Widgets/Pro/RadialChartsWidget.php
+++ b/packages/plugin/src/Widgets/Pro/RadialChartsWidget.php
@@ -32,6 +32,8 @@ class RadialChartsWidget extends AbstractWidget implements ExtraWidgetInterface
 
     public ?string $chartType = null;
 
+    public ?bool $includeSpam = null;
+
     public static function displayName(): string
     {
         return Freeform::getInstance()->name.' '.Freeform::t('Radial Chart');
@@ -64,6 +66,10 @@ class RadialChartsWidget extends AbstractWidget implements ExtraWidgetInterface
 
         if (null === $this->chartType) {
             $this->chartType = WidgetsService::CHART_DONUT;
+        }
+
+        if (null === $this->includeSpam) {
+            $this->includeSpam = false;
         }
     }
 
@@ -121,7 +127,13 @@ class RadialChartsWidget extends AbstractWidget implements ExtraWidgetInterface
             }
         }
 
-        $chartData = $this->getChartsService()->getRadialFormSubmissionData($rangeStart, $rangeEnd, $formList);
+        $chartData = $this->getChartsService()->getRadialFormSubmissionData(
+            $rangeStart,
+            $rangeEnd,
+            $formList,
+            (bool) $this->includeSpam
+        );
+
         $chartData->setChartType($this->chartType);
 
         return $chartData;

--- a/packages/plugin/src/templates/_widgets/linear-charts/settings.html
+++ b/packages/plugin/src/templates/_widgets/linear-charts/settings.html
@@ -56,6 +56,15 @@
     errors: settings.getErrors('aggregate')
 }) }}
 
+{{ forms.lightswitchField({
+    label: "Include Spam Submissions"|t('freeform'),
+    instructions: "Include submissions marked as spam in the chart data."|t('freeform'),
+    id: 'includeSpam',
+    name: 'includeSpam',
+    on: settings.includeSpam,
+    errors: settings.getErrors('includeSpam')
+}) }}
+
 {{ forms.checkboxSelectField({
     label: "Forms"|t('freeform'),
     instructions: "Select the forms for which submission data should be included."|t('freeform'),

--- a/packages/plugin/src/templates/_widgets/radial-charts/settings.html
+++ b/packages/plugin/src/templates/_widgets/radial-charts/settings.html
@@ -48,6 +48,15 @@
     errors: settings.getErrors('dateRange')
 }) }}
 
+{{ forms.lightswitchField({
+    label: "Include Spam Submissions"|t('freeform'),
+    instructions: "Include submissions marked as spam in the chart data."|t('freeform'),
+    id: 'includeSpam',
+    name: 'includeSpam',
+    on: settings.includeSpam,
+    errors: settings.getErrors('includeSpam')
+}) }}
+
 {% if fieldValueSettings is defined and fieldValueSettings %}
 
     {{ forms.selectField({

--- a/packages/plugin/src/translations/de/freeform.php
+++ b/packages/plugin/src/translations/de/freeform.php
@@ -2138,6 +2138,8 @@ return [
     'Last 60 days' => 'Letzte 60 Tage',
     'Last 90 days' => 'Letzte 90 Tage',
     'Display all Form Data as a Single Combined Line' => 'Alle Formulardaten als einzelne kombinierte Linie anzeigen',
+    'Include Spam Submissions' => 'Spam-Übermittlungen einschließen',
+    'Include submissions marked as spam in the chart data.' => 'Als Spam markierte Übermittlungen in die Diagrammdaten einbeziehen.',
     'Select the forms for which submission data should be included.' => 'Wählen Sie die Formulare aus, für die Einsendedaten enthalten sein sollen.',
     'Limit' => 'Limit',
     'The maximum number of submissions to show.' => 'Die maximale Anzahl anzuzeigender Einsendungen.',

--- a/packages/plugin/src/translations/en/freeform.php
+++ b/packages/plugin/src/translations/en/freeform.php
@@ -2138,6 +2138,8 @@ return [
     'Last 60 days' => 'Last 60 days',
     'Last 90 days' => 'Last 90 days',
     'Display all Form Data as a Single Combined Line' => 'Display all Form Data as a Single Combined Line',
+    'Include Spam Submissions' => 'Include Spam Submissions',
+    'Include submissions marked as spam in the chart data.' => 'Include submissions marked as spam in the chart data.',
     'Select the forms for which submission data should be included.' => 'Select the forms for which submission data should be included.',
     'Limit' => 'Limit',
     'The maximum number of submissions to show.' => 'The maximum number of submissions to show.',

--- a/packages/plugin/src/translations/fr/freeform.php
+++ b/packages/plugin/src/translations/fr/freeform.php
@@ -2138,6 +2138,8 @@ return [
     'Last 60 days' => '60 derniers jours',
     'Last 90 days' => '90 derniers jours',
     'Display all Form Data as a Single Combined Line' => 'Afficher toutes les données de formulaire comme une seule ligne combinée',
+    'Include Spam Submissions' => 'Inclure les soumissions spam',
+    'Include submissions marked as spam in the chart data.' => 'Inclure les soumissions marquées comme spam dans les données du graphique.',
     'Select the forms for which submission data should be included.' => 'Sélectionnez les formulaires pour lesquels les données de contribution doivent être incluses.',
     'Limit' => 'Limite',
     'The maximum number of submissions to show.' => 'Le nombre maximum de soumissions à afficher.',

--- a/packages/plugin/src/translations/it/freeform.php
+++ b/packages/plugin/src/translations/it/freeform.php
@@ -2138,6 +2138,8 @@ return [
     'Last 60 days' => 'Ultimi 60 giorni',
     'Last 90 days' => 'Ultimi 90 giorni',
     'Display all Form Data as a Single Combined Line' => 'Visualizza tutti i dati del modulo come un’unica riga combinata',
+    'Include Spam Submissions' => 'Includi le sottomissioni spam',
+    'Include submissions marked as spam in the chart data.' => 'Includi nei dati del grafico le sottomissioni contrassegnate come spam.',
     'Select the forms for which submission data should be included.' => 'Seleziona i moduli per i quali devono essere inclusi i dati di invio.',
     'Limit' => 'Limite',
     'The maximum number of submissions to show.' => 'Il numero massimo di invii da mostrare.',

--- a/packages/plugin/src/translations/nl/freeform.php
+++ b/packages/plugin/src/translations/nl/freeform.php
@@ -2138,6 +2138,8 @@ return [
     'Last 60 days' => 'Afgelopen 60 dagen',
     'Last 90 days' => 'Afgelopen 90 dagen',
     'Display all Form Data as a Single Combined Line' => 'Toon alle formuliergegevens als een enkele gecombineerde regel',
+    'Include Spam Submissions' => 'Spaminzendingen opnemen',
+    'Include submissions marked as spam in the chart data.' => 'Inzendingen die als spam zijn gemarkeerd opnemen in de grafiekgegevens.',
     'Select the forms for which submission data should be included.' => 'Selecteer de formulieren waarvoor indieningsgegevens moeten worden opgenomen.',
     'Limit' => 'Limiet',
     'The maximum number of submissions to show.' => 'Het maximale aantal inzendingen dat kan worden weergegeven.',


### PR DESCRIPTION
Fixes: https://github.com/solspace/craft-freeform/issues/2598

By default - spam not included:

<img width="422" height="604" alt="SCR-20260806-qmwk" src="https://github.com/user-attachments/assets/9bdbe7c2-6bf0-426c-a7cb-73610f03076e" />

Toggle new option on:

<img width="442" height="171" alt="SCR-20260806-qmyq" src="https://github.com/user-attachments/assets/d1d1b612-f512-45ef-9b9f-46d20c6d6e49" />

Spam now included:

<img width="405" height="570" alt="SCR-20260806-qnai" src="https://github.com/user-attachments/assets/e9905fc5-1b81-4f70-ae38-1ee7420a9bb2" />

