### PR TITLE
fix(SFT-2998): load forms with empty freeform_forms_sites map after Craft 5 upgrade

### DIFF
--- a/packages/plugin/src/Services/FormsService.php
+++ b/packages/plugin/src/Services/FormsService.php
@@ -678,9 +678,13 @@ class FormsService extends BaseService implements FormHandlerInterface
                 'sites.handle AS siteHandle',
                 'sites.name AS siteName',
             ])
-            ->innerJoin(FormSiteRecord::TABLE.' fs', 'fs.[[formId]] = forms.[[id]]')
-            ->innerJoin(Table::SITES.' sites', 'sites.[[id]] = fs.[[siteId]]')
-            ->andWhere(['in', 'sites.[[handle]]', $sites])
+            ->leftJoin(FormSiteRecord::TABLE.' fs', 'fs.[[formId]] = forms.[[id]]')
+            ->leftJoin(Table::SITES.' sites', 'sites.[[id]] = fs.[[siteId]]')
+            ->andWhere([
+                'or',
+                ['in', 'sites.[[handle]]', $sites],
+                ['not', ['exists', (new Query())->from(FormSiteRecord::TABLE.' fs_check')->where('[[fs_check.formId]] = [[forms.id]]')]],
+            ])
         ;
     }
 

--- a/packages/plugin/src/Tests/Services/FormsServiceTest.php
+++ b/packages/plugin/src/Tests/Services/FormsServiceTest.php
@@ -2,6 +2,7 @@
 
 namespace Solspace\Freeform\Tests\Services;
 
+use craft\db\Query;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use Solspace\Freeform\Bundles\Attributes\Property\PropertyProvider;
@@ -54,13 +55,15 @@ class FormsServiceTest extends TestCase
         $method = new \ReflectionMethod(FormsService::class, 'attachSitesToQuery');
         $method->invoke($service, $query, 'dutch-site');
 
-        $this->assertSame(
-            [
-                'and',
-                ['forms.id' => 42],
-                ['in', 'sites.[[handle]]', ['dutch-site']],
-            ],
-            $query->where,
-        );
+        $this->assertSame('and', $query->where[0]);
+        $this->assertSame(['forms.id' => 42], $query->where[1]);
+
+        $siteFilter = $query->where[2];
+        $this->assertSame('or', $siteFilter[0]);
+        $this->assertSame(['in', 'sites.[[handle]]', ['dutch-site']], $siteFilter[1]);
+
+        $this->assertSame('not', $siteFilter[2][0]);
+        $this->assertSame('exists', $siteFilter[2][1][0]);
+        $this->assertInstanceOf(Query::class, $siteFilter[2][1][1]);
     }
 }

--- a/packages/plugin/src/migrations/m260807_145446_BackfillEmptyFormSitesMap.php
+++ b/packages/plugin/src/migrations/m260807_145446_BackfillEmptyFormSitesMap.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Solspace\Freeform\migrations;
+
+use craft\db\Migration;
+use craft\db\Query;
+use Solspace\Freeform\Records\Form\FormSiteRecord;
+use Solspace\Freeform\Records\FormRecord;
+
+class m260807_145446_BackfillEmptyFormSitesMap extends Migration
+{
+    public function safeUp(): bool
+    {
+        $mapTable = FormSiteRecord::TABLE;
+        if (!$this->db->tableExists($mapTable)) {
+            return true;
+        }
+
+        $formIds = (new Query())
+            ->select('id')
+            ->from(FormRecord::TABLE)
+            ->column()
+        ;
+
+        $siteIds = (new Query())
+            ->select('id')
+            ->from('{{%sites}}')
+            ->column()
+        ;
+
+        if (!$formIds || !$siteIds) {
+            return true;
+        }
+
+        $mappedFormIds = (new Query())
+            ->select('formId')
+            ->distinct()
+            ->from($mapTable)
+            ->column()
+        ;
+
+        $mappedFormIds = array_flip(array_map('intval', $mappedFormIds));
+
+        foreach ($formIds as $formId) {
+            if (isset($mappedFormIds[(int) $formId])) {
+                continue;
+            }
+
+            foreach ($siteIds as $siteId) {
+                $this->insert(
+                    $mapTable,
+                    [
+                        'formId' => $formId,
+                        'siteId' => $siteId,
+                    ],
+                );
+            }
+        }
+
+        return true;
+    }
+
+    public function safeDown(): bool
+    {
+        return true;
+    }
+}


### PR DESCRIPTION
Fixes: https://github.com/solspace/craft-freeform/issues/2599