### PR TITLE
fix(SFT-3016): preserve today date-picker limits for cached forms

### DIFF
--- a/packages/plugin/src/Fields/Implementations/Pro/DatetimeField.php
+++ b/packages/plugin/src/Fields/Implementations/Pro/DatetimeField.php
@@ -606,6 +606,14 @@ class DatetimeField extends AbstractField implements PlaceholderInterface, DateP
             $value = $this->getValue();
         }
 
+        $minDate = $this->getMinDate() === 'today'
+            ? 'today'
+            : $this->getGeneratedMinDate($this->getFormat());
+
+        $maxDate = $this->getMaxDate() === 'today'
+            ? 'today'
+            : $this->getGeneratedMaxDate($this->getFormat());
+
         $attributes = $this->getAttributes()
             ->getInput()
             ->clone()
@@ -623,8 +631,8 @@ class DatetimeField extends AbstractField implements PlaceholderInterface, DateP
             ->set('data-datepicker-enabledate', $hasDate)
             ->set('data-datepicker-clock_24h', $this->isClock24h())
             ->set('data-datepicker-locale', $this->getSupportedLocale($locale))
-            ->set('data-datepicker-min-date', $this->getGeneratedMinDate($this->getFormat()))
-            ->set('data-datepicker-max-date', $this->getGeneratedMaxDate($this->getFormat()))
+            ->set('data-datepicker-min-date', $minDate)
+            ->set('data-datepicker-max-date', $maxDate)
         ;
 
         if ($this->isUseDatepicker()) {


### PR DESCRIPTION
The cached rendered input now contains `data-datepicker-min-date="today"` rather than `data-datepicker-min-date="2026-08-19"`.

Flatpickr then resolves minDate to today in the browser:

```
document.querySelector('[data-datepicker]')?._flatpickr.config.minDate // Wed Aug 19 2026 00:00:00 GMT+0100 (Irish Time)
```