### PR TITLE
fix(#2623): preserve rules and button settings during form import

### DIFF
--- a/packages/plugin/src/Bundles/Backup/DTO/Page.php
+++ b/packages/plugin/src/Bundles/Backup/DTO/Page.php
@@ -7,4 +7,5 @@ class Page
     public string $uid;
     public string $label;
     public Layout $layout;
+    public array $metadata = [];
 }

--- a/packages/plugin/src/Bundles/Backup/Export/FileExportReader.php
+++ b/packages/plugin/src/Bundles/Backup/Export/FileExportReader.php
@@ -195,6 +195,7 @@ class FileExportReader extends BaseExporter
                 $page->uid = $pageJson['uid'];
                 $page->layout = $this->parseLayout($pageJson['layout']);
                 $page->label = $pageJson['label'];
+                $page->metadata = $pageJson['metadata'] ?? [];
 
                 $form->pages->add($page);
             }

--- a/packages/plugin/src/Bundles/Backup/Export/FreeformFormsExporter.php
+++ b/packages/plugin/src/Bundles/Backup/Export/FreeformFormsExporter.php
@@ -55,6 +55,7 @@ use Solspace\Freeform\Form\Form as FreeformForm;
 use Solspace\Freeform\Form\Layout\Layout as FreeformLayout;
 use Solspace\Freeform\Freeform;
 use Solspace\Freeform\Library\DataObjects\FormTemplate;
+use Solspace\Freeform\Library\Helpers\JsonHelper;
 use Solspace\Freeform\Library\Helpers\StringHelper;
 use Solspace\Freeform\Library\Helpers\StringHelper as FreeformStringHelper;
 use Solspace\Freeform\Library\Integrations\IntegrationInterface;
@@ -63,6 +64,7 @@ use Solspace\Freeform\Models\Settings;
 use Solspace\Freeform\Records\FavoriteFieldRecord;
 use Solspace\Freeform\Records\Form\FormFieldRecord;
 use Solspace\Freeform\Records\Form\FormIntegrationRecord;
+use Solspace\Freeform\Records\Form\FormPageRecord;
 use Solspace\Freeform\Records\Form\FormSiteRecord;
 use Solspace\Freeform\Records\FormGroupsEntriesRecord;
 use Solspace\Freeform\Records\FormGroupsRecord;
@@ -165,6 +167,13 @@ class FreeformFormsExporter extends BaseExporter
         foreach ($forms as $index => $form) {
             /** @var FormFieldRecord[] $formFieldRecords */
             $formFieldRecords = FormFieldRecord::find()
+                ->where(['formId' => $form->getId()])
+                ->indexBy('uid')
+                ->all()
+            ;
+
+            /** @var FormPageRecord[] $formPageRecords */
+            $formPageRecords = FormPageRecord::find()
                 ->where(['formId' => $form->getId()])
                 ->indexBy('uid')
                 ->all()
@@ -274,6 +283,9 @@ class FreeformFormsExporter extends BaseExporter
                 $exportedPage->uid = $page->getUid();
                 $exportedPage->layout = $this->compileLayout($page->getLayout(), $formFieldRecords);
                 $exportedPage->label = $page->getLabel();
+
+                $pageRecord = $formPageRecords[$page->getUid()] ?? null;
+                $exportedPage->metadata = JsonHelper::decode($pageRecord?->metadata ?? [], true) ?? [];
 
                 $exported->pages->add($exportedPage);
             }

--- a/packages/plugin/src/Bundles/Backup/Import/FreeformImporter.php
+++ b/packages/plugin/src/Bundles/Backup/Import/FreeformImporter.php
@@ -357,23 +357,31 @@ class FreeformImporter
                 $pageRecord->label = $page->label;
                 $pageRecord->layoutId = $layoutRecord->id;
                 $pageRecord->order = $pageIndex;
-                $pageRecord->metadata = json_encode([
-                    'buttons' => [
-                        'layout' => 'save back|submit',
-                        'attributes' => [
-                            'container' => [],
-                            'column' => [],
-                            'submit' => [],
-                            'back' => [],
-                            'save' => [],
-                        ],
-                        'submitLabel' => 'Submit',
-                        'back' => true,
-                        'backLabel' => 'Back',
-                        'save' => false,
-                        'saveLabel' => 'Save',
+
+                $pageMetadata = $page->metadata;
+                $pageMetadata['buttons'] ??= [
+                    'layout' => 'save back|submit',
+                    'attributes' => [
+                        'container' => [],
+                        'column' => [],
+                        'submit' => [],
+                        'back' => [],
+                        'save' => [],
                     ],
-                ]);
+                    'submitLabel' => 'Submit',
+                    'back' => true,
+                    'backLabel' => 'Back',
+                    'save' => false,
+                    'saveLabel' => 'Save',
+                ];
+
+                $notificationTemplateId = $pageMetadata['buttons']['notificationTemplate'] ?? null;
+                if (null !== $notificationTemplateId) {
+                    $mappedNotificationTemplateId = $this->notificationTransferIdMap[$notificationTemplateId] ?? null;
+                    $pageMetadata['buttons']['notificationTemplate'] = $mappedNotificationTemplateId;
+                }
+
+                $pageRecord->metadata = json_encode($pageMetadata);
 
                 $pageRecord->save();
 
@@ -386,7 +394,7 @@ class FreeformImporter
             foreach ($form->rules as $rule) {
                 $ruleRecord = RuleRecord::findOne(['uid' => $rule->uid]);
                 if ($ruleRecord) {
-                    if ($isStrategySkip) {
+                    if ($isStrategySkip && $this->hasTypedRuleRecord($rule->type, $ruleRecord->id)) {
                         continue;
                     }
                     $ruleRecord->delete();
@@ -482,6 +490,25 @@ class FreeformImporter
 
             $this->sse->message('progress', 1);
         }
+    }
+
+    private function hasTypedRuleRecord(string $ruleType, int $ruleId): bool
+    {
+        $recordClass = match ($ruleType) {
+            FieldRule::class => FieldRuleRecord::class,
+            PageRule::class => PageRuleRecord::class,
+            ButtonRule::class => ButtonRuleRecord::class,
+            SubmitFormRule::class => SubmitFormRuleRecord::class,
+            NotificationRule::class => NotificationRuleRecord::class,
+            IntegrationRule::class => IntegrationRuleRecord::class,
+            default => null,
+        };
+
+        if (!$recordClass) {
+            return false;
+        }
+
+        return $recordClass::find()->where(['id' => $ruleId])->exists();
     }
 
     private function importLayout(Layout $layout, FormRecord $formRecord): array


### PR DESCRIPTION
## Summary

Fixes #2623.

Form exports and imports now preserve conditional rules and page button settings, including custom button layouts and labels.

## Changes

* Include page metadata in form exports.
* Restore page metadata when importing forms.
* Remap notification template references used by page buttons.
* Retain default button settings when importing older exports without page metadata.
* Detect orphaned base rule records and recreate the missing typed rules instead of skipping them.

## How to test

1. Create a form with two fields.
2. Add a conditional rule to one field.
3. Customize the submit button label and button layout.
4. Export and delete the form.
5. Import the exported form using the default **Skip** behavior.
6. Confirm that the conditional rule, button label, and button layout are preserved.

---

- Fixed an issue where importing forms could omit conditional rules and reset custom button layouts and labels.